### PR TITLE
Cambios menores

### DIFF
--- a/cr_electronic_invoice/__manifest__.py
+++ b/cr_electronic_invoice/__manifest__.py
@@ -23,7 +23,6 @@
 			 'data/mail_template_data.xml',
 			 'views/account_journal_views.xml',
 			 'views/electronic_invoice_views.xml',
-			 'views/report_sales_invoice_qweb.xml',
 	         'security/ir.model.access.csv',
 	         ],
 	'installable': True,

--- a/cr_electronic_invoice/data/data.xml
+++ b/cr_electronic_invoice/data/data.xml
@@ -9,7 +9,7 @@
 			<field name="interval_number">5</field>
 			<field name="interval_type">minutes</field>
 			<field name="numbercall">-1</field>
-			<field name="doall" eval="True" />
+			<field name="doall" eval="False" />
 		</record>
 	</data>
 </openerp>

--- a/cr_electronic_invoice/views/electronic_invoice_views.xml
+++ b/cr_electronic_invoice/views/electronic_invoice_views.xml
@@ -388,19 +388,23 @@
 					<field name="invoice_id" domain="[('number_electronic', '!=', False)]" attrs="{'readonly':[('state','!=','draft')]}"/>
 					<field name="state_tributacion" readonly="1"/>
 					<field name="fname_xml_respuesta_tributacion" invisible="1" readonly="1"/>
-					<field name="xml_respuesta_tributacion" filename="fname_xml_respuesta_tributacion" readonly="1"/>
+					<field name="xml_respuesta_tributacion" filename="fname_xml_respuesta_tributacion"/>
 					<field name="state_invoice_partner" invisible="1"/>
 					<field name="state_send_invoice" invisible="1"/>
 					<field name="fname_xml_comprobante" invisible="1" readonly="1"/>
-					<field name="xml_comprobante" filename="fname_xml_comprobante" readonly="1"/>
+					<field name="xml_comprobante" filename="fname_xml_comprobante"/>
+					
 					<!--<field name="electronic_invoice_return_message" readonly="1"/>-->
 				</field>
 				<xpath expr="//field[@name='invoice_line_ids']//tree//field[@name='discount']" position="after">
 					<field name="discount_note"/>
 					<field name="exoneration_id" />
 				</xpath>
-
-				<button name="action_invoice_cancel" position="attributes">
+				<xpath expr="//button[@name='action_invoice_cancel']" position="after">
+					<button name="charge_xml_data" type="object" string="Cargar datos desde XMLs" colspan="2" attrs="{'invisible':['|', ('state_tributacion','!=', False), '|', ('xml_comprobante', '=', False), ('xml_respuesta_tributacion', '=', False)]}" />
+					<button name="action_consultar_hacienda" type="object" string="Consultar Hacienda" colspan="2" attrs="{'invisible':[('state_tributacion','=', False)]}"/>
+				</xpath>
+				<button name="190" position="attributes">
 					<attribute name="invisible">1</attribute>
 				</button>
 			</field>
@@ -411,14 +415,16 @@
 			<field name="model">account.invoice</field>
 			<field name="inherit_id" ref="account.invoice_supplier_form"/>
 			<field name="arch" type="xml">
+				<xpath expr="//button[@name='action_invoice_cancel']" position="after">
+					<button name="send_acceptance_message" type="object" string="Enviar Mensaje Receptor" colspan="2" attrs="{'invisible':[('state_send_invoice','!=', False)]}"/>
+					<button name="action_consultar_hacienda" type="object" string="Consultar Hacienda" colspan="2" />
+				</xpath>
 				<xpath expr="//group[1]" position="after">
 					<group string="Facturación Electrónica" col="2">
 						<group>
-							<field name="fname_xml_supplier_approval" invisible="1"/>
-							<field name="xml_supplier_approval" filename="fname_xml_supplier_approval"/>
-							<button name="charge_xml_data" type="object" string="Cargar datos desde XML" colspan="2" attrs="{'invisible':[('state','!=','draft')]}"/>
-							<button name="send_xml" type="object" string="Enviar XML" colspan="2" attrs="{'invisible':[('state','!=','open')]}"/>
-							<button name="action_consultar_hacienda" type="object" string="Consultar Hacienda" colspan="2" />
+							<field name="fname_xml_supplier_approval" invisible="1" />
+							<field name="xml_supplier_approval" filename="fname_xml_supplier_approval" />
+							<button name="charge_xml_data" type="object" string="Cargar datos desde XML" colspan="2" attrs="{'invisible':[('state','!=', 'draft')]}" />
 						</group>
 						<group>
 							<field name="state_invoice_partner"/>


### PR DESCRIPTION
- El formato del teléfono: odoo elimina cualquier caracter no númerico cuando alguien digita telefonos
- El formato de email: acepta varios emails separados por coma
- formato de cédula: odoo elimina guines y letras mientras no sea cedula extranjera
- se removió la validación de los totales al enviar el mensaje receptor. Por la forma en que usa Odoo el tipo de cambio, a veces no  calsan por un par de cétimos de colón.
- se puede enviar el mensaje receptor aunque la factura no esté validada. Casos donde ha costado hacer que los totales de las facturas calcen por impuestos, exoneraciones u otros (pasa mucho con walmart, que hay que ir ingresando línea por línea y revisando si está exonerado o no), si se van a pasar los 8 días, mejor la aceptan y siguen más tranquilos ingresando el detalle en odoo. 
- se movió el botón para que esté arriba con las acciones
- Se agregó una opción de consulta hacienda a las facturas de proveedores (a veces da error al enviar el mensaje receptor a hacienda, pero al consultarlo aparece como aceptado). Otro botón en la parte superior de acciones.
- Al cargar el XML en factura de proveedor, se eliminó la validación del nodo total impuesto, facturas que contienen puros productos exonerados,  no traen ese nodo o lo traen en cero.
- se cambió tarea programada consulta hacienda: doall = false (para que no ejecute las veces que no se corrió si el servidor se detuvo por alguna razón)