### PR TITLE
[v11] función send_file nativa

### DIFF
--- a/cr_electronic_invoice/models/functions.py
+++ b/cr_electronic_invoice/models/functions.py
@@ -162,7 +162,7 @@ def send_file(inv, token, date, xml, env, url):
     comprobante['emisor'] = {}
     comprobante['emisor']['tipoIdentificacion'] = Emisor.find('Identificacion').find('Tipo').text
     comprobante['emisor']['numeroIdentificacion'] = Emisor.find('Identificacion').find('Numero').text
-    if Receptor is not None:
+    if Receptor is not None and Receptor.find('Identificacion') is not None:
         comprobante['receptor'] = {}
         comprobante['receptor']['tipoIdentificacion'] = Receptor.find('Identificacion').find('Tipo').text
         comprobante['receptor']['numeroIdentificacion'] = Receptor.find('Identificacion').find('Numero').text


### PR DESCRIPTION
Se modifica la función **send_file** para que envíe el comprobante electrónico sin utilizar el API de CRLibre, se realiza basado en el código del API de CRLibre que se encuentra en https://github.com/CRLibre/API_Hacienda/blob/master/api/contrib/send/send.php