### PR TITLE
[v11] ajuste en función token_hacienda

### DIFF
--- a/cr_electronic_invoice/models/functions.py
+++ b/cr_electronic_invoice/models/functions.py
@@ -161,8 +161,11 @@ def make_xml_invoice(inv, tipo_documento, consecutivo, date, sale_conditions, me
 
 
 def token_hacienda(inv, env, url):
-
-    url = 'https://idp.comprobanteselectronicos.go.cr/auth/realms/rut-stag/protocol/openid-connect/token'
+    
+    if env == 'api-stag':
+        url = 'https://idp.comprobanteselectronicos.go.cr/auth/realms/rut-stag/protocol/openid-connect/token'
+    elif env == 'api-prod':
+        url = 'https://idp.comprobanteselectronicos.go.cr/auth/realms/rut/protocol/openid-connect/token'
 
     data = {
         'client_id': env,


### PR DESCRIPTION
Se modifica la función **token_hacienda** para que obtenga el token tanto del ambiente de prueba como del ambiente de producción,  este cambio ya se había hecho y aprobado en #86 pero se nos deshizo en #90, se solicita cambiarlo nuevamente :)